### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,9 @@
 ---
 
 name: Release
+permissions:
+  contents: read
+  pull-requests: write
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/apenella/gitlabcli/security/code-scanning/1](https://github.com/apenella/gitlabcli/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow involves checking out code, setting up Go, and running GoReleaser, the `contents: read` permission is sufficient for most steps. Additionally, the `pull-requests: write` permission might be required if GoReleaser interacts with pull requests (e.g., updating release notes). 

The `permissions` block should be added at the root level of the workflow to apply to all jobs, ensuring consistent and minimal permissions across the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
